### PR TITLE
Add AI Agent Safety Starter Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Harness components organized by the problem they solve, not by vendor.
 
 ### Permissions & Authorization
 
+- [AI Agent Safety Starter Pack](https://github.com/el-zachariah/ai-agent-safety-starter-pack) — Local-first preflight scanner plus handoff templates for turning repo instructions, MCP/tool configs, package scripts, workflow files, and secret-adjacent filenames into a concrete permissions/verification gate before coding agents get tool access.
 - [Beyond Permission Prompts](https://www.anthropic.com/engineering/beyond-permission-prompts) — Structured authorization patterns for agents: how to give agents the right permissions without relying on prompt-level trust.
 - [OWASP LLM06:2025 — Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/) — OWASP's authoritative definition of the "excessive agency" risk: over-provisioned functions, unnecessary permissions, and missing approval mechanisms. The standard checklist for auditing harness permission scope against principle of least privilege.
 - [GitHub Enterprise — Governing Agents](https://wellarchitected.github.com/library/governance/recommendations/governing-agents/) — April 2026 GitHub official guide for enterprise agent governance: MCP server registry curation with ruleset-protected configurations, agent environment standardization via `copilot-setup-steps.yml`, ephemeral runner enforcement, and cloud-agent firewall allowlisting. The most concrete published reference for governing agent fleets at scale without creating bottlenecks.


### PR DESCRIPTION
Adds a local-first AI-agent repo preflight scanner and handoff-template resource to the permissions/authorization harness section.

Why it fits this list:
- addresses a concrete harness problem: deciding what a coding agent may read/run before repo, package-script, MCP/tool, workflow, or secret-adjacent scope is granted;
- generalizes across Claude Code, Codex-style CLI agents, Cursor, GitHub Copilot instructions, MCP configs, devcontainers, Replit, and similar harnesses;
- links to the free public repo rather than a paid checkout page, with a sample risky repo and `/agent-preflight` command users can inspect before adopting it.
