### PR TITLE
[Harness] Add DSH Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,9 @@ Reusable starting points for harness artifacts. Copy and adapt.
 
 ---
 
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) — Cross-platform desktop host for installing, running, health-checking, and supervising DeepSeek Harness locally. It makes harness lifecycle, health state, logs, and packaged releases inspectable from one local control surface, which is useful for operators who need repeatable supervision instead of ad hoc terminal processes. ![Stars](https://img.shields.io/github/stars/Moresyl/dsh-studio?style=flat-square&label=★&color=yellow)
 
+## Related Awesome Lists
 
 Lists that cover adjacent territory — overlapping but not identical scope.
 

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Reusable starting points for harness artifacts. Copy and adapt.
 
 ---
 
-## Related Awesome Lists
+
 
 Lists that cover adjacent territory — overlapping but not identical scope.
 


### PR DESCRIPTION
## Summary

Adds DSH Studio to **Production Infrastructure & Operations**.

DSH Studio is a cross-platform desktop host for installing, running, health-checking, and supervising DeepSeek Harness locally. It addresses a concrete harness operations problem by making lifecycle state, health, logs, and packaged releases inspectable from one local control surface.

## Why it belongs

- operational control for a local agent harness rather than a general AI application
- exposes repeatable start/stop, health-check, logging, and process-supervision workflows
- MIT-licensed and independently usable without a paid or closed backend
- cross-platform releases for macOS (Apple Silicon and Intel), Windows, and Linux

## Validation

- confirmed there is no existing DSH Studio entry
- placed the entry at the end of Production Infrastructure & Operations
- followed the repository's title, URL, em dash, explanatory note, and star-badge format
- verified the final diff contains only the entry and its separating blank line
- repository: https://github.com/Moresyl/dsh-studio
- release: https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1

Disclosure: I maintain DSH Studio.
