### PR TITLE
Add HOST_DELEGATION_CHECKLIST template

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Reusable starting points for harness artifacts. Copy and adapt.
 | [`templates/PLAN.md`](templates/PLAN.md) | Task planning artifact with milestones and verification gates |
 | [`templates/IMPLEMENT.md`](templates/IMPLEMENT.md) | Implementation log: decisions, deviations, open questions |
 | [`templates/HARNESS_CHECKLIST.md`](templates/HARNESS_CHECKLIST.md) | Review checklist before shipping a harness to production |
+| [`templates/HOST_DELEGATION_CHECKLIST.md`](templates/HOST_DELEGATION_CHECKLIST.md) | Review checklist for harnesses where a sandboxed agent delegates execution to a host it does not control |
 
 ---
 

--- a/templates/HOST_DELEGATION_CHECKLIST.md
+++ b/templates/HOST_DELEGATION_CHECKLIST.md
@@ -1,0 +1,102 @@
+# Host Delegation Checklist
+
+> For harnesses where a sandboxed agent delegates execution to a **host it does
+> not control** — the developer's laptop, a build box, a runner. Work through
+> this before letting such a path run unattended.
+>
+> A failing item is a blocker; a skipped item needs a written justification.
+>
+> Vendor-agnostic: the transport may be a spool directory, a queue, or an RPC
+> channel, and the executor may be an agent, a script runner, or a CI job. Every
+> item below has been the cause of a real, silent production failure.
+
+## Transport durability
+
+- [ ] The channel survives **both ends disappearing** — sandbox suspended mid-task,
+      host rebooted, laptop asleep. A held socket or an in-flight HTTP request does not.
+- [ ] A submitted task is durable **before** any work begins, so a crash between
+      "accepted" and "started" loses nothing.
+- [ ] Requests carry an **idempotency key**. A retry after an ambiguous timeout
+      must not run a deploy or a migration twice.
+- [ ] Results are written **atomically** (write-temp-then-rename), so a reader never
+      sees a half-written result and treats it as complete.
+- [ ] The reader is **idempotent**: polling a finished task repeatedly returns the
+      same answer, so a caller that crashes mid-wait can resume.
+
+## Staleness — the failure nobody tests
+
+- [ ] Queued work has a **maximum age**, not just a maximum runtime. A host that was
+      asleep for six hours must not wake up and execute the whole backlog.
+- [ ] Expiry produces a **normal, readable result** (a distinct status), not silence.
+      The caller has already given up; it needs to know why.
+- [ ] Executing hours-late work is treated as **worse than not executing it** for any
+      task with side effects — deploys, pushes, notifications.
+
+## Executor liveness
+
+- [ ] "Registered with the service manager" is **not** treated as "running." Health
+      is proven by a **round-trip**, not by presence in a process table.
+- [ ] The executor cannot enter a state where the supervisor believes it is alive
+      while it serves nothing. Verify by killing it in each way it can actually die.
+- [ ] A restart loop that **cannot succeed** is detected as such. A supervisor that
+      respawns a job failing on a configuration error will do so forever, silently.
+- [ ] Startup failures that occur **before** the runtime initialises still produce a
+      diagnosable signal. If the process dies before it can log, the logs are empty
+      and every symptom points at the wrong layer.
+      *(Concrete case: on macOS 13+, a working directory under `~/Documents`,
+      `~/Desktop` or `~/Downloads` is TCC-protected. A shell you type into inherits
+      consent so it runs by hand; the service manager has none, cannot `chdir`, and
+      kills the job with `EX_CONFIG` before any runtime starts. Empty logs, infinite
+      respawn, "registered but dead.")*
+
+## Path and identity agreement
+
+- [ ] The writer and the executor **derive the channel location the same way**. If one
+      reads an env var and the other a service definition, they will disagree exactly
+      once, in production.
+- [ ] A disagreement is reported as a **configuration error naming both paths**, not as
+      a timeout. "No result in 30s — is the daemon running?" sends the reader to debug
+      a healthy executor.
+- [ ] Every copy of the client resolves identically, and a test asserts it. Duplicated
+      resolution logic drifts silently.
+
+## Trust envelope
+
+- [ ] The executor runs from an **allowlist** it owns, not arbitrary commands from the
+      caller. Path traversal out of that allowlist is rejected after resolution.
+- [ ] Authentication uses **constant-time comparison**. A token checked with `==` leaks
+      its prefix to a patient caller.
+- [ ] The caller can **narrow** its own permissions per task but never widen them past
+      the host owner's ceiling.
+- [ ] Destructive or costly work passes a **plan-approval gate** the host owner controls,
+      and the gate's absence fails **closed or explicitly opt-in** — never silently open.
+- [ ] Spend and resource ceilings are enforced **host-side**. A ceiling the caller sets
+      is a suggestion.
+
+## Output hygiene
+
+- [ ] Output is **bounded** while streaming, keeping the tail, so one runaway task cannot
+      exhaust memory or disk.
+- [ ] Truncation is **flagged in the result**; a consumer must be able to tell "no output"
+      from "output dropped."
+- [ ] Secrets are redacted on the **write path**, covering every artifact — result file,
+      progress log, status line. Redacting at read time misses whatever already hit disk.
+- [ ] Redaction is documented as **best-effort**. An unrecognised secret shape will pass
+      through, and pretending otherwise is worse than saying so.
+
+## Diagnosability
+
+- [ ] A single command reports end-to-end health and **exits non-zero on failure**, so it
+      is usable from CI and from a support request.
+- [ ] Failure messages name the **cause and the fix**, not the symptom. "Registered but not
+      running — try starting it" is useless when starting it cannot work.
+- [ ] Every distinct failure mode is **distinguishable from the outside**: rejected before
+      execution, timed out, failed to spawn, cancelled, expired. Branch on a stable code,
+      never on prose.
+
+---
+
+*Contributed from production experience building a filesystem-mediated host
+delegation bridge. Each item above corresponds to a failure that shipped and had
+to be diagnosed after the fact — the TCC and path-agreement items in particular
+were live for weeks while every surface reported healthy.*


### PR DESCRIPTION
Per CONTRIBUTING's **"Template contributions"** section — a harness artifact used in production.

## What this covers

A review checklist for the case where a **sandboxed agent delegates execution to a host it does not control**: the developer's laptop, a build box, a runner. That path has a failure surface most harness checklists don't touch, because the interesting failures are on the *transport and liveness* side rather than the prompt side.

Sections: transport durability, staleness, executor liveness, path/identity agreement, trust envelope, output hygiene, diagnosability.

## Why it's worth including

Every item corresponds to a failure that **actually shipped** and had to be diagnosed after the fact. Two examples of the flavour:

- **Startup failures that happen before the runtime initialises.** On macOS 13+, a working directory under `~/Documents` is TCC-protected. A shell you type into inherits consent, so the daemon runs fine by hand — but the service manager has none, can't `chdir`, and kills the job with `EX_CONFIG` *before* any runtime starts. Empty logs, infinite respawn, and `launchctl` reporting the job as registered. Every symptom points at the wrong layer.

- **Writer and executor deriving the channel location differently.** One reads an env var, the other a service definition. They disagree exactly once, in production, and the resulting error ("no result in 30s — is the daemon running?") sends you to debug a perfectly healthy executor.

Both were live for **weeks** while every surface reported healthy.

## Conformance to CONTRIBUTING

- **Specific harness problem** — sandboxing, permissions, verification, agent-loop durability
- **Vendor-agnostic by principle** — the transport may be a spool directory, a queue, or an RPC channel; the executor may be an agent, a script runner, or a CI job. The one platform-specific detail (TCC) is marked as a concrete illustration of a general class, not a requirement
- **Production-used**, not theoretical

Registered in the templates table in `README.md`. `verify_urls.py` passes.

Happy to trim, resection, or drop the parenthetical case study if you'd prefer it tighter.